### PR TITLE
feat: SIGNAL-7060 filter out large messages during termination instead of sending to Kafka

### DIFF
--- a/lib/kafee/producer/async_worker.ex
+++ b/lib/kafee/producer/async_worker.ex
@@ -250,7 +250,6 @@ defmodule Kafee.Producer.AsyncWorker do
   # developers to handle.
   @doc false
   def terminate(_reason, %{send_task: nil} = state) do
-    count = :queue.len(state.queue)
     terminate_send(state)
   end
 

--- a/test/kafee/producer/async_worker_test.exs
+++ b/test/kafee/producer/async_worker_test.exs
@@ -351,6 +351,44 @@ defmodule Kafee.Producer.AsyncWorkerTest do
       assert logs =~ "exception was raised trying to send the remaining messages to Kafka"
       assert 11 = logs |> String.split("Unsent Kafka message") |> length()
     end
+
+    @tag capture_log: true
+    test "any leftover messages that are large during shutdown gets logged and will not publish", %{
+      pid: pid,
+      topic: topic,
+      state: state
+    } do
+      [small_message_1, small_message_2] = BrodApi.generate_producer_message_list(topic, 2)
+      message_fixture = File.read!("test/support/example/large_message.json")
+      large_message_fixture = String.duplicate(message_fixture, 10)
+
+      # This message will skip being sent to Kafka, and only be logged
+      large_message_1 =
+        topic
+        |> BrodApi.generate_producer_message()
+        |> Map.put(:value, large_message_fixture)
+        |> Map.put(:key, "large_msg_1")
+
+      remaining_messages = [small_message_1, large_message_1, small_message_2]
+      state = %{state | queue: :queue.from_list(remaining_messages), send_timeout: :infinity}
+
+      log =
+        capture_log(fn ->
+          assert :ok = AsyncWorker.terminate(:normal, state)
+          Process.sleep(@wait_timeout)
+        end)
+
+      remaining_brod_messages = BrodApi.to_kafka_message([small_message_1, small_message_2])
+      assert_called_once(:brod.produce(_client_id, ^topic, 0, _key, ^remaining_brod_messages))
+
+      async_worker_state = pid |> Patch.Listener.target() |> :sys.get_state()
+      assert 0 == :queue.len(async_worker_state.queue)
+
+      assert log =~ "Message in queue is too large, will not push to Kafka"
+      assert log =~ "send 2 messages to Kafka before terminate"
+      refute log =~ "exception was raised trying to send the remaining messages to Kafka"
+      refute log =~ "Unsent Kafka message"
+    end
   end
 
   describe "build_message_batch/1" do

--- a/test/kafee/producer/async_worker_test.exs
+++ b/test/kafee/producer/async_worker_test.exs
@@ -400,7 +400,7 @@ defmodule Kafee.Producer.AsyncWorkerTest do
       [small_message] = BrodApi.generate_producer_message_list(topic, 1)
       small_message_unit_size = kafka_message_size_bytes(small_message)
 
-      small_message_total = Kernel.ceil(max_request_bytes / small_message_unit_size)
+      small_message_total = Kernel.ceil(max_request_bytes / small_message_unit_size) * 2
       remaining_messages = BrodApi.generate_producer_message_list(topic, small_message_total)
 
       state = %{state | queue: :queue.from_list(remaining_messages), send_timeout: :infinity}

--- a/test/kafee/producer/async_worker_test.exs
+++ b/test/kafee/producer/async_worker_test.exs
@@ -411,7 +411,7 @@ defmodule Kafee.Producer.AsyncWorkerTest do
           Process.sleep(@wait_timeout)
         end)
 
-      # just asswert if called; lower level :brod code might split up the messages into more then one call
+      # just assert if called; lower level :brod code might split up the messages into more then one call
       assert_called(:brod.produce(_client_id, ^topic, 0, _key, _messages))
 
       async_worker_state = pid |> Patch.Listener.target() |> :sys.get_state()

--- a/test/kafee/producer/async_worker_test.exs
+++ b/test/kafee/producer/async_worker_test.exs
@@ -391,7 +391,7 @@ defmodule Kafee.Producer.AsyncWorkerTest do
     end
 
     @tag capture_log: true
-    test "should handle leftover messages which are each small sized but have a total size exceeds max_request_bytes",
+    test "should handle leftover messages which are each small sized but have a total size exceeding max_request_bytes",
          %{
            pid: pid,
            topic: topic,


### PR DESCRIPTION
## Related Ticket(s)

SIGNAL-7060

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem
Messages larger than what Kafka allows will create an error that is not captured by existing `case` clause, mainly because it is happening during process termination flow.

The error tuple is as follows:
`{:not_retriable, {:produce_response_error, "magnam-totam-nobis-est", 0, -1, :message_too_large}}`

GenServer crashing with that error seems to be the Brod producer or the supervisor.

It only happens when `terminate_send` has to deal with message(s) in queue that are larger than allowed, and have pushed it to `:brod.produce()`.

## Details

I tried to catch it as another pattern match in the place where we [do this check in AsyncWorker](https://github.com/stordco/kafee/blob/main/lib/kafee/producer/async_worker.ex#L159), but to no avail.

Now during when the processes are live and working, the existing case clause will handle large messages and emit them out to DataDog logs - the only case where this happens appears to be when `terminate_send` works with the large message (at least that's how I was able to repro the issue in tests).

Therefore the large messages are filtered out of the queue because they are already beyond what Kafka allows, and rest is passed into Kafka during termination.

We can move this logic down to `send_message`, but I wanted to be conservative in our changes and limit the blast radius.

End expected result is that we should be getting the "message too large" DataDog log ( we weren't getting them with this edge case scenario) with the actual message.

Then, next step is to try to trim out the messages in those messages when they are created.
