### PR TITLE
feat: SIGNAL-7060 drop large messages from even attempting to produce into Kafka

### DIFF
--- a/test/kafee/producer_integration_test.exs
+++ b/test/kafee/producer_integration_test.exs
@@ -66,7 +66,6 @@ defmodule Kafee.ProducerIntegrationTest do
         end)
 
       refute log =~ "Message in queue is too large"
-      assert log =~ "brod producer process is currently down"
       assert log =~ "Successfully sent messages to Kafka"
     end
   end


### PR DESCRIPTION
## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->
SIGNAL-7060

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

We were able to trigger another un-supported error where it was not covered by the terminate lifecycle of the GenServer. 

## Details

This PR will proactively handle the large message by dropping it from the queue when the request comes in to add the message to the queue, and log it.

### How to reproduce:

Please see [this ticket](https://stord.atlassian.net/browse/SIGNAL-7089) that goes over how to trigger this in local `wms-ui`.

Note that in `wms-service`, the `mix.exs` should adjust so that `kafee` dependency is referenced from the local path:
```
{:kafee, "~> 3.1", path: "/Users/seungjin.kim/Documents/projects/kafee", override: true},
```

 