### PR TITLE
fix: SIGNAL-7090 UPDATE async worker id setting per partition

### DIFF
--- a/lib/kafee/producer/async_adapter.ex
+++ b/lib/kafee/producer/async_adapter.ex
@@ -281,7 +281,8 @@ defmodule Kafee.Producer.AsyncAdapter do
       |> Keyword.put(:topic, topic)
       |> Keyword.put(:partition, partition)
 
-    custom_child_id = "#{AsyncWorker}#{partition}"
+    brod_client_name = brod_client(producer)
+    custom_child_id = "#{brod_client_name}-AsyncWorker-#{topic}-#{partition}"
 
     with {:error, {:already_started, pid}} <-
            Supervisor.start_child(producer, %{id: custom_child_id, start: {AsyncWorker, :start_link, [worker_options]}}) do

--- a/lib/kafee/producer/async_adapter.ex
+++ b/lib/kafee/producer/async_adapter.ex
@@ -281,7 +281,10 @@ defmodule Kafee.Producer.AsyncAdapter do
       |> Keyword.put(:topic, topic)
       |> Keyword.put(:partition, partition)
 
-    with {:error, {:already_started, pid}} <- Supervisor.start_child(producer, {AsyncWorker, worker_options}) do
+    custom_child_id = "#{AsyncWorker}#{partition}"
+
+    with {:error, {:already_started, pid}} <-
+           Supervisor.start_child(producer, %{id: custom_child_id, start: {AsyncWorker, :start_link, [worker_options]}}) do
       {:ok, pid}
     end
   end

--- a/test/kafee/producer/async_adapter_test.exs
+++ b/test/kafee/producer/async_adapter_test.exs
@@ -110,10 +110,8 @@ defmodule Kafee.Producer.AsyncAdapterTest do
 
       assert 5 == worker_pids |> Enum.uniq() |> length()
 
-      # Send more messages
-      messages = BrodApi.generate_producer_message_list(topic, 5)
-      # change partitions
-      messages = messages |> Enum.with_index(1) |> Enum.map(fn {message, idx} -> %{message | partition: idx} end)
+      # Send more messages through same 5 partitions
+      messages = BrodApi.generate_producer_partitioned_message_list(topic, 5, 5)
 
       assert :ok = MyProducer.produce(messages)
       assert_called(AsyncWorker.queue(_pid, _messages), 10)

--- a/test/support/brod_api.ex
+++ b/test/support/brod_api.ex
@@ -99,7 +99,7 @@ defmodule Kafee.BrodApi do
   """
   def generate_producer_partitioned_message_list(topic, number_of_messages, partitions \\ 1)
 
-  def generate_producer_partitioned_message_list(topic, number_of_messages, partitions)
+  def generate_producer_partitioned_message_list(_topic, number_of_messages, partitions)
       when length(number_of_messages) < length(partitions) do
     {:error, "number of partitions is greather than number of messages"}
   end


### PR DESCRIPTION
## Related Ticket(s)

SIGNAL-7090

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

While trying to use the BroadwayAdapter, I found that something in the AsyncAdapter was pushing the messages to just one partition.

## Details

I was able to trace it back to the `get_or_create_worker` function. I found out that unless the `:id` is customized, and just `AsyncWorker` is used, then it doesn't matter whichever distinct name is used for Registry - the same worker pid is going be to tried to be retrieved. This means even though a different partition is found from AsyncAdapter, when it comes to get the associated worker pid - the first one created will be returned for any subsequent worker retrieval attempt.

Downstream effect is the consuming phase gets slowed down - only one partition will have all of the messages for the consumer group. Meaning, no matter how many consumers you have in the consumer group - only one consumer will be handling all of the messages pushed into the topic, across all of the partitions.

The fix is using a custom id that appends the partition number to the atom `AsyncWorker`. I string-concatenated it and didn't explicitly change it to atom, but I suspect it would be done under the hood.

As to why this was not detected in production, is probably because of the robustness of BEAM - a self-healing of crashed supervisor tree would end up picking random workers to be created, resulting in distributing messages across partitions.

But because for firehose we're passing a lot more messages, this became more visible.

TL;DR - I think this would increase overall performance of production consumption of Kafka messages for anywhere using AsyncAdapter. Meaning, this would increase consumption performance of services that consume from topic `wms-service`, which are GAS and WMS Bridge.

