### PR TITLE
feat: SIGNAL-7060 preemtively drop large messages from queue

### DIFF
--- a/lib/kafee/producer/async_adapter.ex
+++ b/lib/kafee/producer/async_adapter.ex
@@ -246,7 +246,13 @@ defmodule Kafee.Producer.AsyncAdapter do
         |> Message.set_request_id_from_logger()
         |> Message.validate!()
       end)
-      |> Enum.group_by(fn %{topic: topic, partition: partition} -> {topic, partition} end)
+      |> Enum.group_by(fn %{topic: topic, partition: partition} ->
+        if topic == "wms-service--firehose" do
+          IO.inspect(partition, label: "AsyncAdapter.produce - PRODUCING MESSAGE - partition:")
+        end
+
+        {topic, partition}
+      end)
 
     for {{topic, partition}, messages} <- message_groups do
       :ok = queue(producer, options, topic, partition, messages)
@@ -259,6 +265,15 @@ defmodule Kafee.Producer.AsyncAdapter do
           :ok | {:error, term()}
   defp queue(producer, options, topic, partition, messages) do
     with {:ok, pid} <- get_or_create_worker(producer, options, topic, partition) do
+      if topic == "wms-service--firehose" do
+        partitions = messages |> Enum.map(& &1.partition)
+
+        IO.inspect(%{partition_for_worker: partition, partitions: partitions, worker_pid: pid},
+          label: "AsyncAdapter.queue - passing arguments to AsyncWorker.queue",
+          charlists: false
+        )
+      end
+
       AsyncWorker.queue(pid, messages)
     end
   end
@@ -297,9 +312,24 @@ defmodule Kafee.Producer.AsyncAdapter do
       |> brod_client()
       |> AsyncWorker.process_name(topic, partition)
 
+    if topic == "wms-service--firehose" do
+      IO.inspect(registry_key, label: "AsyncWorker.get_worker - registry_key")
+    end
+
     case Registry.lookup(registry_name, registry_key) do
-      [{pid, _value}] -> {:ok, pid}
-      [] -> {:error, :not_found}
+      [{pid, _value}] ->
+        if topic == "wms-service--firehose" do
+          IO.inspect(partition, label: "AsyncWorker.get_worker - got the pid for partition")
+        end
+
+        {:ok, pid}
+
+      [] ->
+        if topic == "wms-service--firehose" do
+          IO.inspect(partition, label: "AsyncWorker.get_worker - NO FOUND!")
+        end
+
+        {:error, :not_found}
     end
   end
 
@@ -307,6 +337,10 @@ defmodule Kafee.Producer.AsyncAdapter do
           {:ok, pid()} | {:error, term()}
   defp get_or_create_worker(producer, options, topic, partition) do
     with {:error, :not_found} <- get_worker(producer, topic, partition) do
+      if topic == "wms-service--firehose" do
+        IO.inspect(%{options: options, partition: partition}, label: "AsyncAdapter.get_or_create_worker() arguments")
+      end
+
       create_worker(producer, options, topic, partition)
     end
   end

--- a/lib/kafee/producer/async_worker.ex
+++ b/lib/kafee/producer/async_worker.ex
@@ -346,6 +346,7 @@ defmodule Kafee.Producer.AsyncWorker do
 
     Enum.each(messages_beyond_max_bytes, fn message ->
       Logger.error("Message in queue is too large, will not push to Kafka", data: message)
+      IO.inspect(kafka_message_size_bytes(message) / (1024 * 1024), label: "MESSAGE SIZE (MB)")
     end)
 
     messages_within_max_bytes_queue

--- a/lib/kafee/producer/async_worker.ex
+++ b/lib/kafee/producer/async_worker.ex
@@ -346,7 +346,6 @@ defmodule Kafee.Producer.AsyncWorker do
 
     Enum.each(messages_beyond_max_bytes, fn message ->
       Logger.error("Message in queue is too large, will not push to Kafka", data: message)
-      IO.inspect(kafka_message_size_bytes(message) / (1024 * 1024), label: "MESSAGE SIZE (MB)")
     end)
 
     messages_within_max_bytes_queue

--- a/lib/kafee/producer/async_worker.ex
+++ b/lib/kafee/producer/async_worker.ex
@@ -257,6 +257,12 @@ defmodule Kafee.Producer.AsyncWorker do
     # Update state with queue just with messages that are acceptable
     state = %{state | queue: queue_without_large_messages(state.queue, state.max_request_bytes)}
 
+    count = :queue.len(state.queue)
+
+    if count > 0 do
+      Logger.info("Attempting to send #{count} messages to Kafka before terminate")
+    end
+
     terminate_send(state)
   end
 
@@ -341,12 +347,6 @@ defmodule Kafee.Producer.AsyncWorker do
     Enum.each(messages_beyond_max_bytes, fn message ->
       Logger.error("Message in queue is too large, will not push to Kafka", data: message)
     end)
-
-    count = :queue.len(messages_within_max_bytes_queue)
-
-    if count > 0 do
-      Logger.info("Attempting to send #{count} messages to Kafka before terminate")
-    end
 
     messages_within_max_bytes_queue
   end

--- a/test/kafee/producer_integration_test.exs
+++ b/test/kafee/producer_integration_test.exs
@@ -66,7 +66,6 @@ defmodule Kafee.ProducerIntegrationTest do
         end)
 
       refute log =~ "Message in queue is too large"
-      assert log =~ "brod producer process is currently down"
       assert log =~ "Successfully sent messages to Kafka"
     end
   end


### PR DESCRIPTION
## Related Ticket(s)
SIGNAL-7060

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

We added logic to drop large messages during termination, but we still observed raw `:message_too_large` errors bubbling up from brod code. Due to the sheer traffic in topic `wms-service--firehose`, these errors are observed once or twice every other day.


## Details

Preemptively drop large messages from even being attempted. Currently prior to this PR, `AsyncWorker.build_message_batch()` would attempt to push the message out to Kafka without checking the size.

This PR will check at the `AsyncWorker.queue()` lifecycle, so when request comes into this GenServer to put a new message to the queue, it will check and drop the large message - if it goes over `state.max_request_bytes`.

The dropped messages follow the same logging code which should push out the message to DataDog.

