### PR TITLE
fix: flaky test

### DIFF
--- a/test/kafee/producer/async_adapter_test.exs
+++ b/test/kafee/producer/async_adapter_test.exs
@@ -128,9 +128,7 @@ defmodule Kafee.Producer.AsyncAdapterTest do
 
       # clean up because kafka in test only has one partition, so errors happen
       capture_log(fn ->
-        for pid <- worker_pids do
-          GenServer.stop(pid)
-        end
+        stop_supervised(MyProducer)
       end)
     end
   end


### PR DESCRIPTION
## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

Use a better way to shut down gracefully and capture any logs that come out of it

## Details

Using a `stop_supervised()` to cascade shut down all of its children processes ahead of test shutting down, so capture_log can eat the logs.
