### PR TITLE
feat: allow setting a custom client_id and strip Elixir. from the def…

### DIFF
--- a/lib/kafee/consumer.ex
+++ b/lib/kafee/consumer.ex
@@ -76,6 +76,17 @@ defmodule Kafee.Consumer do
                       """,
                       required: true,
                       type: :string
+                    ],
+                    client_id: [
+                      doc: """
+                      A custom client id to use for the Kafka consumer.
+
+                      By default it will use the name of the module.
+
+                      This is useful when observing the stream lineage.
+                      """,
+                      required: false,
+                      type: :string
                     ]
                   )
 
@@ -200,7 +211,7 @@ defmodule Kafee.Consumer do
         full_opts = Keyword.merge(unquote(Macro.escape(opts)), args)
 
         %{
-          id: __MODULE__,
+          id: Keyword.get(full_opts, :client_id, inspect(__MODULE__)),
           start: {Kafee.Consumer, :start_link, [__MODULE__, full_opts]}
         }
       end

--- a/lib/kafee/producer.ex
+++ b/lib/kafee/producer.ex
@@ -89,6 +89,17 @@ defmodule Kafee.Producer do
                       required: true,
                       type: {:or, [:atom, {:fun, 4}]},
                       type_doc: "`Kafee.partition_fun()`"
+                    ],
+                    client_id: [
+                      doc: """
+                      A custom client id to use for the Kafka producer.
+
+                      By default it will use the name of the module.
+
+                      This is useful when observing the stream lineage.
+                      """,
+                      required: false,
+                      type: :string
                     ]
                   )
 
@@ -216,7 +227,7 @@ defmodule Kafee.Producer do
         full_opts = Keyword.merge(unquote(Macro.escape(opts)), args)
 
         %{
-          id: __MODULE__,
+          id: Keyword.get(full_opts, :client_id, inspect(__MODULE__)),
           start: {Kafee.Producer, :start_link, [__MODULE__, full_opts]}
         }
       end


### PR DESCRIPTION
…ault

## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [ ] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

<!--
What is the problem you're solving or feature you're implementing? Link to any Jira tickets or previous discussions of the issue.
-->

## Details

<!--
Include a brief overview of the technical process you took (or are going to take!) to get from the problem to the solution.
-->

When observing the stream lineage, the producers and consumers setup by the library look like `Elixir.SomeService.SomeTopicProducer`. 

By default, this change turns that into `SomeService.SomeTopicProducer`. In some cases, you might not even want this, and instead prefer to setup a custom `client_id`. This allows you the option to pass in `client_id: :topic_secret_producer`.
