### PR TITLE
chore: SIGNAL-7217 increase timeout for Task.await_many to account for 15 sec DB timeouts + buffer

### DIFF
--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -81,6 +81,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
                           type: :boolean,
                           doc: """
                           Flag that decides batch processing will be done asynchronously.
+                          The async operations run through Task.await_many/2 with a max timeout of 120_000 msec.
                           """
                         ]
                       ]
@@ -218,7 +219,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
       # No need for Task.Supervisor as it is not running under a GenServer,
       # and Kafee.Consumer.Adapter.push_message does already have error handling.
       tasks = Enum.map(messages, &Task.async(fn -> do_consumer_work(&1, consumer, options) end))
-      Task.await_many(tasks)
+      Task.await_many(tasks, 120_000)
     else
       Enum.each(messages, fn message -> do_consumer_work(message, consumer, options) end)
     end

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -219,7 +219,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
       # No need for Task.Supervisor as it is not running under a GenServer,
       # and Kafee.Consumer.Adapter.push_message does already have error handling.
       tasks = Enum.map(messages, &Task.async(fn -> do_consumer_work(&1, consumer, options) end))
-      Task.await_many(tasks, 120_000)
+      Task.await_many(tasks, :infinity)
     else
       Enum.each(messages, fn message -> do_consumer_work(message, consumer, options) end)
     end


### PR DESCRIPTION
## Related Ticket(s)
SIGNAL-7217

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

Load testing in staging showed that sometimes the event handlers processed work past the default 5 second timeout of `Task.await_many`, therefore timing out. It's not frequent, but still significant, and an additional timeout to worry about.

## Details

Giving it `:infinity` timeout because it is well beyond the 15 second DB connection timeout, and also past the default 60 sec API call timeouts from HTTPoison or 30 second socket timeout for Req[/finch timeout](https://hexdocs.pm/req/Req.html#new/1).

That way there's at least a ceiling, but still enough time to do work without worrying about a 5 second timeout.