### PR TITLE
fix: update kafee consumer handle_failure/2 fn

### DIFF
--- a/lib/kafee/consumer.ex
+++ b/lib/kafee/consumer.ex
@@ -192,6 +192,8 @@ defmodule Kafee.Consumer do
   @doc false
   defmacro __using__(opts \\ []) do
     quote location: :keep, bind_quoted: [opts: opts, module: __CALLER__.module] do
+      require Logger
+
       @behaviour Kafee.Consumer
 
       @doc false
@@ -230,8 +232,7 @@ defmodule Kafee.Consumer do
         inspected_message = inspect(message)
         inspected_error = inspect(error)
 
-        raise RuntimeError,
-          message: """
+        Logger.error("""
           An error has been raised while processing a Kafka message.
 
           Message:
@@ -239,7 +240,7 @@ defmodule Kafee.Consumer do
 
           Error:
           #{inspected_error}
-          """
+        """, kafee_message: message, error: error)
       end
 
       defoverridable child_spec: 1, handle_message: 1, handle_failure: 2


### PR DESCRIPTION
## Related Ticket(s)

N/A

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [X] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

The built in `Kafee.Consumer.handle_failure/2` function raises an error which causes problems down the line. It should instead return an `:ok` like the behaviour specifies.

## Details

Change `raise RuntimeError` to `Logger.error`
