### PR TITLE
chore: SIGNAL-7345 add metadata for message in a different key

### DIFF
--- a/lib/kafee/producer/async_worker.ex
+++ b/lib/kafee/producer/async_worker.ex
@@ -177,7 +177,10 @@ defmodule Kafee.Producer.AsyncWorker do
       case error do
         {:error, {:producer_down, {:not_retriable, {_, _, _, _, :message_too_large}}}}
         when length(sent_messages) == 1 ->
-          Logger.error("Message in queue is too large", data: data_to_log_for_large_message_error(sent_messages))
+          Logger.error("Message in queue is too large",
+            large_message_metadata: data_to_log_for_large_message_error(sent_messages)
+          )
+
           %{state | queue: :queue.drop(queue)}
 
         {:error, {:producer_down, {:not_retriable, {_, _, _, _, :message_too_large}}}} ->
@@ -364,7 +367,7 @@ defmodule Kafee.Producer.AsyncWorker do
 
     Enum.each(messages_beyond_max_bytes, fn message ->
       Logger.error("Message in queue is too large, will not push to Kafka",
-        data: data_to_log_for_large_message_error(message)
+        large_message_metadata: data_to_log_for_large_message_error(message)
       )
     end)
 


### PR DESCRIPTION
## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->
SIGNAL-7345

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem
The new metadata keys are not coming through in the `data` key, as there might be some code that is overriding the `data` key.

<!--
What is the problem you're solving or feature you're implementing? Link to any Jira tickets or previous discussions of the issue.
-->

## Details

<!--
Include a brief overview of the technical process you took (or are going to take!) to get from the problem to the solution.
-->
This is test; but we can see if it is actually the reason why we are not seeing the metadata values.