### PR TITLE
chore: Correct documentation to include start.count metric

### DIFF
--- a/lib/kafee/producer.ex
+++ b/lib/kafee/producer.ex
@@ -190,7 +190,7 @@ defmodule Kafee.Producer do
 
   The recommended collection of these metrics can be done via:
 
-      summary("kafee.produce.stop.count",
+      counter("kafee.produce.start.count",
         tags: [:topic, :partition]
       ),
       summary("kafee.produce.stop.duration",


### PR DESCRIPTION
## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

SIGNAL-7436

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

<!--
What is the problem you're solving or feature you're implementing? Link to any Jira tickets or previous discussions of the issue.
-->

I was looking at our telemetry on wms-service, and I realized that we had a duplicate entry for `kafee.produce.stop`. I looked into it, and noticed that the documentation had this problem as well and omitted `start.count` despite mentioning it lines above. Furthermore, Datadog has never caught the `kafee.produce.stop.count` metric.  This leads me to believe that this was incorrect and this should be `start` instead.

## Details

<!--
Include a brief overview of the technical process you took (or are going to take!) to get from the problem to the solution.
-->

I switched this to `counter` as well because that's what we typically use, but let me know if that's off base.
