### PR TITLE
fix: Improve Kafee exception handling

### DIFF
--- a/lib/kafee/consumer/adapter.ex
+++ b/lib/kafee/consumer/adapter.ex
@@ -79,7 +79,6 @@ defmodule Kafee.Consumer.Adapter do
     :ok
   rescue
     error ->
-      consumer.handle_failure(error, message)
       {:error, error}
   end
 end

--- a/lib/kafee/consumer/adapter.ex
+++ b/lib/kafee/consumer/adapter.ex
@@ -44,7 +44,7 @@ defmodule Kafee.Consumer.Adapter do
       end
 
   """
-  @spec push_message(atom(), Kafee.Consumer.options(), Message.t()) :: :ok
+  @spec push_message(atom(), Kafee.Consumer.options(), Message.t()) :: :ok | {:error, any()}
   def push_message(consumer, options, %Message{} = message) do
     Message.set_logger_metadata(message)
 
@@ -80,6 +80,6 @@ defmodule Kafee.Consumer.Adapter do
   rescue
     error ->
       consumer.handle_failure(error, message)
-      :ok
+      {:error, error}
   end
 end

--- a/lib/kafee/consumer/adapter.ex
+++ b/lib/kafee/consumer/adapter.ex
@@ -44,7 +44,7 @@ defmodule Kafee.Consumer.Adapter do
       end
 
   """
-  @spec push_message(atom(), Kafee.Consumer.options(), Message.t()) :: :ok | {:error, any()}
+  @spec push_message(atom(), Kafee.Consumer.options(), Message.t()) :: :ok | {:error, Exception.t()}
   def push_message(consumer, options, %Message{} = message) do
     Message.set_logger_metadata(message)
 

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -291,8 +291,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
     messages
     |> List.wrap()
     |> Enum.each(fn message ->
-      error = %RuntimeError{message: "Error occurred processing a message - #{inspect(message.status)}"}
-      consumer.handle_failure(error, message)
+      consumer.handle_failure(message.status, message)
     end)
 
     messages

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -288,8 +288,12 @@ defmodule Kafee.Consumer.BroadwayAdapter do
     # function above because `Kafee.Consumer.Adapter.push_message/2` will catch any
     # errors.
 
-    error = %RuntimeError{message: "Error converting a Broadway message to Kafee.Consumer.Message"}
-    messages |> List.wrap() |> Enum.each(&consumer.handle_failure(error, &1))
+    messages
+    |> List.wrap()
+    |> Enum.each(fn message ->
+      error = %RuntimeError{message: "Error occurred processing a message - #{inspect(message.status)}"}
+      consumer.handle_failure(error, message)
+    end)
 
     messages
   end

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -218,7 +218,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
     if batch_config[:async_run] do
       # No need for Task.Supervisor as it is not running under a GenServer,
       # and Kafee.Consumer.Adapter.push_message does already have error handling.
-      tasks = Enum.map(messages, &Task.async(fn -> do_consumer_work(&1, consumer, options) end))
+      tasks = Enum.map(messages, &Task.async(fn -> do_batch_consumer_work(&1, consumer, options) end))
       Task.await_many(tasks, :infinity)
     else
       Enum.each(messages, fn message -> do_consumer_work(message, consumer, options) end)

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -238,6 +238,9 @@ defmodule Kafee.Consumer.BroadwayAdapter do
       Enum.map(messages, &Broadway.Message.failed(&1, reason))
   end
 
+  # Dialyzer can't recognize that :ok is a valid return type for this function
+  # due to the rescue clause in push_message/3
+  @dialyzer {:nowarn_function, do_consumer_work: 3}
   defp do_consumer_work(
          %Broadway.Message{
            data: value,
@@ -262,11 +265,9 @@ defmodule Kafee.Consumer.BroadwayAdapter do
         }
       )
 
-    with :ok <- result do
-      message
-    else
-      error ->
-        Broadway.Message.failed(message, error)
+    case result do
+      :ok -> message
+      error -> Broadway.Message.failed(message, error)
     end
   catch
     kind, reason ->

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -244,7 +244,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
          %Broadway.Message{
            data: value,
            metadata: metadata
-         },
+         } = message,
          consumer,
          options
        ) do

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -227,10 +227,8 @@ defmodule Kafee.Consumer.BroadwayAdapter do
     kind, reason ->
       Logger.error(
         "Caught #{kind} attempting to handle batch : #{Exception.format(kind, reason, __STACKTRACE__)}",
-        kind: kind,
-        reason: reason,
-        consumer: consumer,
-        messages: messages
+        consumer: inspect(consumer),
+        messages: inspect(messages)
       )
 
       # If we catch at this stage we have no way of knowing which messages successfully processed
@@ -272,10 +270,8 @@ defmodule Kafee.Consumer.BroadwayAdapter do
   catch
     kind, reason ->
       Logger.error("Caught #{kind} attempting to process message: #{Exception.format(kind, reason, __STACKTRACE__)}",
-        kind: kind,
-        reason: reason,
-        consumer: consumer,
-        message: message
+        consumer: inspect(consumer),
+        message: inspect(message)
       )
 
       Broadway.Message.failed(message, reason)

--- a/lib/kafee/consumer/broadway_adapter.ex
+++ b/lib/kafee/consumer/broadway_adapter.ex
@@ -231,7 +231,7 @@ defmodule Kafee.Consumer.BroadwayAdapter do
         kind: kind,
         reason: reason,
         consumer: consumer,
-        message: message
+        messages: messages
       )
 
       Enum.map(messages, &Broadway.Message.failed(&1, reason))

--- a/test/kafee/consumer/broadway_adapter_integration_test.exs
+++ b/test/kafee/consumer/broadway_adapter_integration_test.exs
@@ -130,7 +130,9 @@ defmodule Kafee.Consumer.BroadwayAdapterIntegrationTest do
 
       assert_receive message
       IO.inspect(message)
-      assert_receive {:error_reason, "%RuntimeError{message: \"Error handling a message for key-fail-2\"}"}
+
+      assert_receive {:error_reason,
+                      "%RuntimeError{message: \"Error converting a Broadway message to Kafee.Consumer.Message\"}"}
     end
   end
 end

--- a/test/kafee/consumer/broadway_adapter_integration_test.exs
+++ b/test/kafee/consumer/broadway_adapter_integration_test.exs
@@ -128,11 +128,11 @@ defmodule Kafee.Consumer.BroadwayAdapterIntegrationTest do
       # assert they were done asynchronously
       assert 100 == task_pids |> Enum.uniq() |> length
 
-      assert_receive message
-      IO.inspect(message)
+      assert_receive {:error_reason,
+                      "%{:failed, {:error, %RuntimeError{message: \\\"Error handling a message for key-fail-1\\\"}}}\"}"}
 
       assert_receive {:error_reason,
-                      "%RuntimeError{message: \"Error converting a Broadway message to Kafee.Consumer.Message\"}"}
+                      "{:failed, {:error, %RuntimeError{message: \\\"Error handling a message for key-fail-2\\\"}}}}"}
     end
   end
 end

--- a/test/kafee/consumer/broadway_adapter_integration_test.exs
+++ b/test/kafee/consumer/broadway_adapter_integration_test.exs
@@ -128,7 +128,8 @@ defmodule Kafee.Consumer.BroadwayAdapterIntegrationTest do
       # assert they were done asynchronously
       assert 100 == task_pids |> Enum.uniq() |> length
 
-      assert_receive {:error_reason, "%RuntimeError{message: \"Error handling a message for key-fail-1\"}"}
+      assert_receive message
+      IO.inspect(message)
       assert_receive {:error_reason, "%RuntimeError{message: \"Error handling a message for key-fail-2\"}"}
     end
   end

--- a/test/kafee/consumer/broadway_adapter_integration_test.exs
+++ b/test/kafee/consumer/broadway_adapter_integration_test.exs
@@ -129,10 +129,10 @@ defmodule Kafee.Consumer.BroadwayAdapterIntegrationTest do
       assert 100 == task_pids |> Enum.uniq() |> length
 
       assert_receive {:error_reason,
-                      "%{:failed, {:error, %RuntimeError{message: \\\"Error handling a message for key-fail-1\\\"}}}\"}"}
+                      "{:failed, {:error, %RuntimeError{message: \"Error handling a message for key-fail-1\"}}}"}
 
       assert_receive {:error_reason,
-                      "{:failed, {:error, %RuntimeError{message: \\\"Error handling a message for key-fail-2\\\"}}}}"}
+                      "{:failed, {:error, %RuntimeError{message: \"Error handling a message for key-fail-2\"}}}"}
     end
   end
 end


### PR DESCRIPTION
## Related Ticket(s)

<!--
Enter the Jira issue below in the following format: PROJECT-##
-->

SIGNAL-7451

## Checklist

<!--
For each bullet, ensure your pr meets the criteria and write a note explaining how this PR relates. Mark them as complete as they are done. All top-level checkboxes should be checked regardless of their relevance to the pr with a note explaining whether they are relevant or not.
-->

- [x] Code conforms to the [Elixir Styleguide](https://github.com/christopheradams/elixir_style_guide)

## Problem

<!--
What is the problem you're solving or feature you're implementing? Link to any Jira tickets or previous discussions of the issue.
-->

We've noticed on wms-service that under high load, sometimes we get error messages in our consumers. These bubble up and trigger the exception handling of `Broadway`. This PR aims to more gracefully catch exits that occur in `Task.await_many/2` and mark the messages as failed.

## Details

<!--
Include a brief overview of the technical process you took (or are going to take!) to get from the problem to the solution.
-->

There is also a shift in approach - instead of manually calling `handle_failure` and then returning the message in failed cases, I am opting to shift our usage to reflect the library. `handle_failure` is called by the library itself, so there's no need for Kafee to call it manually if we use `Broadway.Message.failed/2`